### PR TITLE
Don't use the pre-release version of Redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "postcss-reporter": "^1.3.0",
     "postcss-simple-extend": "^1.0.0",
     "postcss-simple-vars": "^1.0.1",
-    "redis": "^2.6.0-0",
+    "redis": "^2.5.3",
     "slug": "^0.9.1",
     "source-map-support": "^0.4.0",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
Fixes #405.