### PR TITLE
Update Push API Payload Chrome support

### DIFF
--- a/features/push.md
+++ b/features/push.md
@@ -6,7 +6,7 @@ firefox_status: 44
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Push_API
 spec_url: https://w3c.github.io/push-api/
 chrome_ref: 5416033485586432
-chrome_footnote: Payloads are not currently supported
+chrome_footnote: Currently doesn't support the Web Push standard, but uses the proprietary GCM protocol
 ie_ref: Push API
 caniuse_ref: push-api
 ---


### PR DESCRIPTION
Fixes #441. Chrome 50 now support payload, but uses the proprietary GCM protocol