### PR TITLE
Fix wrong webkit_ref given for CSS variables

### DIFF
--- a/features/css-variables.md
+++ b/features/css-variables.md
@@ -6,7 +6,7 @@ firefox_status: 31
 mdn_url: https://developer.mozilla.org/Web/CSS/Using_CSS_variables
 spec_url: http://dev.w3.org/csswg/css-variables/
 caniuse_ref: css-variables
-webkit_ref: CSS Properties and Values API Level 1
+webkit_ref: CSS Variables
 chrome_ref: 6401356696911872
 ie_ref: CSS Custom Properties (a.k.a. CSS Variables)
 ---


### PR DESCRIPTION
The `webkit_ref` given for CSS variables is "CSS Properties and Values API Level 1" instead of "CSS Variables", incorrectly indicating that Safari has not shipped the feature.