### PR TITLE
Fail explicitly when a caniuse.com feature doesn't exist

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -199,7 +199,7 @@ function fillInUsingCanIUseData(canIUseData, features) {
       const data = canIUseData.data[feature.caniuse_ref];
 
       if (!data) {
-        throw new Error(`Can't find '${feature.caniuse_ref}' caniuse.com feature.`);
+        throw new Error(`Can't find '${feature.caniuse_ref}' feature on caniuse.com.`);
       }
 
       [{

--- a/engine/index.js
+++ b/engine/index.js
@@ -198,6 +198,10 @@ function fillInUsingCanIUseData(canIUseData, features) {
     if (feature.caniuse_ref) {
       const data = canIUseData.data[feature.caniuse_ref];
 
+      if (!data) {
+        throw new Error(`Can't find '${feature.caniuse_ref}' caniuse.com feature.`);
+      }
+
       [{
         browser: 'opera',
         engine: 'opera',


### PR DESCRIPTION
Right now the error printed when a feature doesn't exist (e.g. in #467) is quite confusing:
```
[08:59:15] TypeError: Cannot read property 'stats' of undefined
    at /home/travis/build/mozilla/platform-status/engine/index.js:216:13
    at Array.forEach (native)
    at /home/travis/build/mozilla/platform-status/engine/index.js:208:10
    at Array.forEach (native)
    at fillInUsingCanIUseData (/home/travis/build/mozilla/platform-status/engine/index.js:197:12)
    at /home/travis/build/mozilla/platform-status/engine/index.js:628:5
    at process._tickCallback (node.js:438:9)
```

After this PR, it will become:
```
[01:19:16] Error: Can't find 'clip-path' caniuse.com feature.
    at /home/marco/Documenti/workspace/platatus/engine/index.js:317:15
    at Array.forEach (native)
    at fillInUsingCanIUseData (/home/marco/Documenti/workspace/platatus/engine/index.js:312:12)
    at /home/marco/Documenti/workspace/platatus/engine/index.js:749:5
    at process._tickCallback (internal/process/next_tick.js:109:7)
```