### PR TITLE
Explicitly fail when there's an error while parsing a feature file

### DIFF
--- a/engine/fixtureParser.js
+++ b/engine/fixtureParser.js
@@ -19,6 +19,11 @@ export default class FixtureParser {
 
   readFile(src) {
     const meta = matter.read(src);
+
+    if (Object.keys(meta.data).length === 0) {
+        throw new Error(`Error while parsing '${src}'.`);
+    }
+
     const summary = markdown.renderInline(meta.content);
     const slug = path.basename(src, '.md');
     const file = path.relative(this.root, src);


### PR DESCRIPTION
This would have prevented manual work in identifying https://github.com/mozilla/platform-status/pull/464#pullrequestreview-22761233.

The build failure was something like:
```
[10:01:53] TypeError: Cannot read property 'toLowerCase' of undefined
    at /home/travis/build/mozilla/platform-status/engine/fixtureParser.js:16:24
    at Array.sort (native)
    at FixtureParser.read (/home/travis/build/mozilla/platform-status/engine/fixtureParser.js:16:8)
    at /home/travis/build/mozilla/platform-status/engine/index.js:616:19
    at process._tickCallback (node.js:385:9)
```

After this PR, it will be something like:
```
[01:25:45] Error: Error while parsing '/home/marco/Documenti/workspace/platatus/features/credential-management.md'.
    at FixtureParser.readFile (/home/marco/Documenti/workspace/platatus/engine/fixtureParser.js:47:13)
    at Array.map (native)
    at FixtureParser.read (/home/marco/Documenti/workspace/platatus/engine/fixtureParser.js:35:80)
    at /home/marco/Documenti/workspace/platatus/engine/index.js:733:39
    at process._tickCallback (internal/process/next_tick.js:109:7)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:393:7)
    at startup (bootstrap_node.js:150:9)
    at bootstrap_node.js:508:3
```