### PR TITLE
fix(features/push): Remove Chrome footnote (only GCM)

### DIFF
--- a/features/push.md
+++ b/features/push.md
@@ -6,7 +6,6 @@ firefox_status: 44
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Push_API
 spec_url: https://w3c.github.io/push-api/
 chrome_ref: 5416033485586432
-chrome_footnote: Currently doesn't support the Web Push standard, but uses the proprietary GCM protocol
 ie_ref: Push API
 caniuse_ref: push-api
 ---


### PR DESCRIPTION
https://developers.google.com/web/updates/2016/07/web-push-interop-wins