### PR TITLE
adding PerformanceNavigationTiming

### DIFF
--- a/features/performance-navigation-timing.md
+++ b/features/performance-navigation-timing.md
@@ -1,0 +1,13 @@
+---
+title: PerformanceNavigationTiming
+category: api, apps
+bugzilla: 1263722
+firefox_status: 58
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
+spec_url: https://w3c.github.io/navigation-timing/#sec-PerformanceNavigationTiming
+chrome_ref: 5409443269312512
+webkit_ref: Navigation Timing Level 2
+
+---
+
+Provides methods and properties to store and retrieve metrics regarding the browser's document navigation events.


### PR DESCRIPTION
I'm not sure if really this should be stated as Navigation Timing Level 2, but most of that has been implemented for ages; PerformanceNavigationTiming is the only new bit. 