### PR TITLE
Fill in Chrome and IE data using caniuse too

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -211,6 +211,14 @@ function fillInUsingCanIUseData(canIUseData, features) {
       {
         browser: 'safari',
         engine: 'webkit',
+      },
+      {
+        browser: 'chrome',
+        engine: 'chrome',
+      },
+      {
+        browser: 'ie',
+        engine: 'ie',
       }].forEach(({ browser, engine }) => {
         if (feature[`${engine}_status`] !== 'unknown') {
           return;


### PR DESCRIPTION
This is especially useful when the external status websites fail (e.g. right now the IE status is failing and we'd have no data for Edge without this PR).