### PR TITLE
Returning lunr to version 1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-uglify": "^3.0.0",
     "handlebars": "^4.0.3",
     "lodash.debounce": "^4.0.8",
-    "lunr": "^2.1.5",
+    "lunr": "^1.0.0",
     "markdown-it": "^8.4.0",
     "mkdirp": "^0.5.1",
     "mozilla-tabzilla": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-uglify": "^3.0.0",
     "handlebars": "^4.0.3",
     "lodash.debounce": "^4.0.8",
-    "lunr": "^1.0.0",
+    "lunr": "1.0.0",
     "markdown-it": "^8.4.0",
     "mkdirp": "^0.5.1",
     "mozilla-tabzilla": "^0.5.1",


### PR DESCRIPTION
Fix #509 

In versions >= 2, the API has changed and it is no longer possible to boost a
field [1]. It is possible to boost and fine-tune other aspects of the search
but this requires further investigation.

[1] https://github.com/olivernn/lunr.js/issues/312