### PR TITLE
Add Bugzilla bug ID and MDN link for the `backdrop-filter` CSS property

### DIFF
--- a/features/css-backdrop-filter.md
+++ b/features/css-backdrop-filter.md
@@ -1,8 +1,9 @@
 ---
 title: CSS backdrop-filter (subset of Filter FX L2)
 category: css, layout
-bugzilla:
+bugzilla: 1178765
 firefox_status: under-consideration
+mdn_url: https://developer.mozilla.org/docs/Web/CSS/backdrop-filter
 spec_url: https://dev.w3.org/fxtf/filters-2/#BackdropFilterPropert
 caniuse_ref: css-backdrop-filter
 webkit_ref: Filter Effects backdrop-filter propery


### PR DESCRIPTION
This adds the Bugzilla bug ID [1178765](https://bugzil.la/1178765 "1178765 - Implement backdrop-filter from Filter Effects Module Level 2") for the [`backdrop-filter`](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter "backdrop-filter - CSS | MDN") CSS property.