### PR TITLE
Fix edge links

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -135,14 +135,14 @@ class IEBrowserFeature extends BrowserFeature {
   get url() {
     const name = this.data.name.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
     return url.format({
-      host: 'dev.modern.ie',
-      pathname: `/platform/status/${name}`,
+      host: 'developer.microsoft.com',
+      pathname: `/en-us/microsoft-edge/platform/status/${name}/`,
       protocol: 'https:',
     });
   }
 }
 
-IEBrowserFeature.defaultUrl = 'https://dev.modern.ie/platform/status/';
+IEBrowserFeature.defaultUrl = 'https://developer.microsoft.com/en-us/microsoft-edge/platform/status/';
 
 const allBrowserFeatures = [
   ['chrome', 'chrome', ChromeBrowserFeature],


### PR DESCRIPTION
Fixes #517 

Note: All locales when used in the link seem to redirect to /en-us/, so all links are /en-us/.