### PR TITLE
Bug 1438139 – JavaScript Modules are shipping in Firefox 60

### DIFF
--- a/features/javascript-modules.md
+++ b/features/javascript-modules.md
@@ -1,0 +1,15 @@
+---
+title: JavaScript Modules
+category: js
+bugzilla: 1240072
+firefox_status: 60
+mdn_url:
+spec_url: https://tc39.github.io/ecma262/#sec-modules
+spec_repo: https://github.com/tc39/ecma262
+caniuse_ref: es6-module
+webkit_ref: modules
+chrome_ref: 5365692190687232
+ie_ref: Modules ES6
+---
+
+Modules allow for easy modularization and encapsulation of JavaScript code across separate files.

--- a/features/javascript-modules.md
+++ b/features/javascript-modules.md
@@ -3,7 +3,7 @@ title: JavaScript Modules
 category: js
 bugzilla: 1240072
 firefox_status: 60
-mdn_url:
+mdn_url: https://hacks.mozilla.org/2015/08/es6-in-depth-modules/
 spec_url: https://tc39.github.io/ecma262/#sec-modules
 spec_repo: https://github.com/tc39/ecma262
 caniuse_ref: es6-module


### PR DESCRIPTION
This adds the platform status for JavaScript Modules to the repository.

### See also:
- mdn/browser-compat-data#1667

### External links:
- https://bugzil.la/1240072
- https://bugzil.la/1438139