### PR TITLE
adding performanceservertiming

### DIFF
--- a/features/performance-navigation-timing.md
+++ b/features/performance-navigation-timing.md
@@ -4,7 +4,7 @@ category: api, apps
 bugzilla: 1263722
 firefox_status: 58
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
-spec_url: https://w3c.github.io/navigation-timing/#sec-PerformanceNavigationTiming
+spec_url: https://w3c.github.io/navigation-timing/
 chrome_ref: 5409443269312512
 webkit_ref: Navigation Timing Level 2
 

--- a/features/performance-server-timing.md
+++ b/features/performance-server-timing.md
@@ -1,0 +1,14 @@
+---
+title: PerformanceServerTiming
+category: api, apps
+bugzilla: 1423495
+firefox_status: 61
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming
+spec_url: https://w3c.github.io/server-timing/
+chrome_ref: 5695708376072192
+ie_ref: Server Timing
+webkit_ref: Navigation Timing Level 2
+
+---
+
+Exposes server metrics that are sent with the response in the Server-Timing HTTP header.


### PR DESCRIPTION
This was the main sizable atomic thing that was added in this release. In this PR I also slightly updated the spec URL of performancenavigationtiming.