### PR TITLE
Added CSS Scroll Snap

### DIFF
--- a/features/css-scroll-snap.md
+++ b/features/css-scroll-snap.md
@@ -1,0 +1,15 @@
+---
+title: CSS Scroll Snap
+category: css
+bugzilla: 1231777
+firefox_status: 68
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap
+spec_url: https://drafts.csswg.org/css-scroll-snap-1/
+spec_repo: https://github.com/w3c/csswg-drafts/tree/master/css-scroll-snap-1
+caniuse_ref: css-snappoints
+webkit_ref: css-scroll-snap-points-module-level-1
+chrome_ref: 5721832506261504
+ie_ref: CSS Scroll Snap Points
+---
+
+Defines a way to define "snap positions", which allow to enforce a scrolling element to stop at specific positions after scrolling it.

--- a/features/css-scroll-snap.md
+++ b/features/css-scroll-snap.md
@@ -12,4 +12,4 @@ chrome_ref: 5721832506261504
 ie_ref: CSS Scroll Snap Points
 ---
 
-Defines a way to define "snap positions", which allow to enforce a scrolling element to stop at specific positions after scrolling it.
+Provides a way to define "snap positions", which enforce the scroll positions that elements should stop at when they have finished scrolling.


### PR DESCRIPTION
This fixes the long-standing issue #549. The current Gecko implementation is behind the flag `layout.css.scroll-snap-v1.enabled`, enabled by default on Firefox Nightly, and will be shipped in [bug 1544136](https://bugzilla.mozilla.org/show_bug.cgi?id=1544136).

I've also added this feature to the [Experimental features page on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features#scroll-snap).