### PR TITLE
docs: Use MDN URL for JavaScript Modules

### DIFF
--- a/features/javascript-modules.md
+++ b/features/javascript-modules.md
@@ -3,7 +3,7 @@ title: JavaScript Modules
 category: js
 bugzilla: 1240072
 firefox_status: 60
-mdn_url: https://hacks.mozilla.org/2015/08/es6-in-depth-modules/
+mdn_url: https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules
 spec_url: https://tc39.github.io/ecma262/#sec-modules
 spec_repo: https://github.com/tc39/ecma262
 caniuse_ref: es6-module


### PR DESCRIPTION
@chrisdavidmills created the [JavaScript Modules guide page](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules) on MDN in [bug 1517546 comment #10](https://bugzilla.mozilla.org/show_bug.cgi?id=1517546#c10), this updates the Firefox Platform Status website to link to MDN, like it was agreed in https://github.com/mozilla/platform-status/pull/520#discussion_r176786389.