### PR TITLE
Added Resize Observer API

### DIFF
--- a/features/resize-observer.md
+++ b/features/resize-observer.md
@@ -1,0 +1,13 @@
+---
+title: Resize Observer API
+category: api, performance
+bugzilla: 1272409
+firefox_status: 69
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Resize_Observer_API
+spec_url: https://drafts.csswg.org/resize-observer/
+chrome_ref: 5705346022637568
+webkit_ref: Resize Observer
+ie_ref: Resize Observer
+---
+
+Observes changes to the size of an elementʼs content rectangle.


### PR DESCRIPTION
The Resize Observer API was [added in Firefox 69](https://bugzilla.mozilla.org/show_bug.cgi?id=1543839).