### PR TITLE
feat: Add “WebXR Device API”

### DIFF
--- a/features/webxr.md
+++ b/features/webxr.md
@@ -1,0 +1,13 @@
+---
+title: "WebXR Device API"
+category: api, apps, device
+bugzilla: 1419190
+firefox_status: in-development
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API
+spec_url: https://immersive-web.github.io/webxr/
+spec_repo: https://github.com/immersive-web/webxr
+chrome_ref: 5680169905815552
+caniuse_ref: webxr
+---
+
+Provides support for exposing virtual reality displays — like the Oculus Rift or HTC Vive — to web apps, enabling developers to create interactive virtual reality scenes on the web platform.

--- a/features/webxr.md
+++ b/features/webxr.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API
 spec_url: https://immersive-web.github.io/webxr/
 spec_repo: https://github.com/immersive-web/webxr
 chrome_ref: 5680169905815552
-caniuse_ref: webxr
+#caniuse_ref: webxr
 ---
 
 Provides support for exposing virtual reality displays — like the Oculus Rift or HTC Vive — to web apps, enabling developers to create interactive virtual reality scenes on the web platform.


### PR DESCRIPTION
This adds the “[WebXR Device API](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API)”, which is now shipped in [Chrome 76](https://www.chromestatus.com/feature/5680169905815552).