### PR TITLE
Revert "fix(webxr): Temporarily disable “Can I use…” link"

### DIFF
--- a/features/webxr.md
+++ b/features/webxr.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API
 spec_url: https://immersive-web.github.io/webxr/
 spec_repo: https://github.com/immersive-web/webxr
 chrome_ref: 5680169905815552
-#caniuse_ref: webxr
+caniuse_ref: webxr
 ---
 
 Provides support for exposing virtual reality displays — like the Oculus Rift or HTC Vive — to web apps, enabling developers to create interactive virtual reality scenes on the web platform.


### PR DESCRIPTION
This reverts commit f9180364db38b04d8b8c5ed39c61f3c2d6a9438c.

“Can I use…” has now added WebXR data in https://github.com/Fyrd/caniuse/pull/5064, so this can now be merged.