### PR TITLE
feat: Add “MathML”

### DIFF
--- a/features/mathml.md
+++ b/features/mathml.md
@@ -1,0 +1,15 @@
+---
+title: MathML
+category: math
+bugzilla: 1495813
+firefox_status: 1
+firefox_footnote: MathML 4 support is in development
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/MathML
+spec_url: https://mathml-refresh.github.io/mathml/
+spec_repo: https://github.com/mathml-refresh/mathml
+chrome_ref: 5240822173794304
+ie_ref: mathml
+caniuse_ref: mathml
+---
+
+Mathematical Markup Language is a XML dialect for describing mathematical notation and capturing both its structure and content.


### PR DESCRIPTION
This adds **MathML** to the **Firefox Platform Status** website.