### PR TITLE
Add caniuse_ref to platform status entries

### DIFF
--- a/features/app-manifest.md
+++ b/features/app-manifest.md
@@ -6,6 +6,7 @@ firefox_status: 58
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/Manifest
 spec_url: https://w3c.github.io/manifest/
 spec_repo: https://github.com/w3c/manifest
+caniuse_ref: web-app-manifest
 chrome_ref: 6488656873259008
 ie_ref: Web Application Manifest
 opera_ref:

--- a/features/background-sync.md
+++ b/features/background-sync.md
@@ -5,6 +5,7 @@ bugzilla: 1217544
 firefox_status: in-development
 spec_url: https://wicg.github.io/BackgroundSync/spec/
 spec_repo: https://github.com/WICG/BackgroundSync
+caniuse_ref: background-sync
 chrome_ref: 6170807885627392
 opera_ref:
 webkit_ref:

--- a/features/canvas-media-capture.md
+++ b/features/canvas-media-capture.md
@@ -6,6 +6,7 @@ firefox_status: 43
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/captureStream
 spec_url: https://w3c.github.io/mediacapture-fromelement/index.html#idl-def-CanvasCaptureMediaStream
 spec_repo: https://github.com/w3c/mediacapture-fromelement
+caniuse_ref: mediacapture-fromelement
 chrome_ref: 4817998447640576
 webkit_ref:
 opera_ref:

--- a/features/css-font-display.md
+++ b/features/css-font-display.md
@@ -5,6 +5,7 @@ bugzilla: 1157064
 firefox_status: 58
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
 spec_url: https://tabatkins.github.io/specs/css-font-display/
+caniuse_ref: css-font-rendering-controls
 chrome_ref: 4799947908055040
 webkit_ref: CSS Font Display
 ---

--- a/features/css-min-max-clamp.md
+++ b/features/css-min-max-clamp.md
@@ -4,8 +4,8 @@ category: css
 firefox_status: 75
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/clamp
 spec_url: https://drafts.csswg.org/css-values-4/#math
+caniuse_ref: css-math-functions
 chrome_ref: 5714277878988800
-caniuse_ref: mdn-css_types_clamp
 ---
 
 CSS functions that allow you to set responsive values with a maximum or maximum value, or both.

--- a/features/css-subgrids.md
+++ b/features/css-subgrids.md
@@ -5,6 +5,7 @@ bugzilla: 1240834
 firefox_status: 71
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid
 spec_url: https://drafts.csswg.org/css-grid-2/#subgrids
+caniuse_ref: css-subgrid
 ---
 
 Allows a CSS grid nested inside another CSS grid to be connected to its containing grid, using the same tracks.

--- a/features/link-rel-preload.md
+++ b/features/link-rel-preload.md
@@ -6,6 +6,7 @@ firefox_status: in-development
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
 spec_url: https://w3c.github.io/preload/
 spec_repo: https://github.com/w3c/preload
+caniuse_ref: link-rel-preload
 chrome_ref: 5757468554559488
 ie_ref: Preload
 webkit_ref: Preload

--- a/features/media-recorder.md
+++ b/features/media-recorder.md
@@ -5,6 +5,7 @@ bugzilla: 803414
 firefox_status: 29
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder
 spec_url: https://w3c.github.io/mediacapture-record/MediaRecorder.html
+caniuse_ref: mediarecorder
 chrome_ref: 5929649028726784
 ie_ref: MediaRecorder
 ---

--- a/features/performance-server-timing.md
+++ b/features/performance-server-timing.md
@@ -5,6 +5,7 @@ bugzilla: 1423495
 firefox_status: 61
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming
 spec_url: https://w3c.github.io/server-timing/
+caniuse_ref: server-timing
 chrome_ref: 5695708376072192
 ie_ref: Server Timing
 webkit_ref: Navigation Timing Level 2

--- a/features/resize-observer.md
+++ b/features/resize-observer.md
@@ -5,6 +5,7 @@ bugzilla: 1272409
 firefox_status: 69
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Resize_Observer_API
 spec_url: https://drafts.csswg.org/resize-observer/
+caniuse_ref: resizeobserver
 chrome_ref: 5705346022637568
 webkit_ref: Resize Observer
 ie_ref: Resize Observer

--- a/features/shared-array-buffer.md
+++ b/features/shared-array-buffer.md
@@ -6,6 +6,7 @@ firefox_status: 46
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 spec_url: https://tc39.github.io/ecmascript_sharedmem/shmem.html
 spec_repo: https://github.com/tc39/ecmascript_sharedmem
+caniuse_ref: sharedarraybuffer
 chrome_ref: 4570991992766464
 ie_ref: Shared Memory and Atomics
 ---

--- a/features/web-assembly.md
+++ b/features/web-assembly.md
@@ -6,6 +6,7 @@ bugzilla: 1188259
 mdn_url: https://developer.mozilla.org/en-US/docs/WebAssembly
 spec_url: https://github.com/WebAssembly/spec
 spec_status: working-draft-or-equivalent
+caniuse_ref: wasm
 chrome_ref: 5453022515691520
 ie_ref: Web Assembly (MVP)
 webkit_ref: WebAssembly

--- a/features/web-authentication.md
+++ b/features/web-authentication.md
@@ -6,6 +6,7 @@ firefox_status: 60
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API
 spec_url: https://w3c.github.io/webauthn/
 spec_repo: https://github.com/w3c/webauthn/
+caniuse_ref: webauthn
 chrome_ref: 5669923372138496
 ie_ref: Web Authentication API
 webkit_ref: Web Authentication

--- a/features/webgl-2.md
+++ b/features/webgl-2.md
@@ -5,6 +5,7 @@ firefox_status: 52
 bugzilla: 889977
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext
 spec_url: https://www.khronos.org/registry/webgl/specs/latest/2.0/
+caniuse_ref: webgl2
 chrome_ref: 6694359164518400
 webkit_ref: WebGL 2
 ie_ref: WebGL 2.0


### PR DESCRIPTION
This PR added `caniuse_ref` to following entries to display caniuse stats on the page.

- app-manifest: [Web App Manifest](https://caniuse.com/#feat=web-app-manifest)
- background-sync: [Background Sync API](https://caniuse.com/#feat=background-sync)
- canvas-media-capture: [Media Capture from DOM Elements API](https://caniuse.com/#feat=mediacapture-fromelement)
- css-font-display: [CSS font-rendering controls](https://caniuse.com/#feat=css-font-rendering-controls)
- css-min-max-clamp: [CSS math functions min(), max() and clamp()](https://caniuse.com/#feat=css-math-functions)
- css-subgrids: [CSS Subgrid](https://caniuse.com/#feat=css-subgrid)
- link-rel-preload: [Resource Hints: preload](https://caniuse.com/#feat=link-rel-preload)
- media-recorder: [MediaRecorder API](https://caniuse.com/#feat=mediarecorder)
- performance-server-timing: [Server Timing](https://caniuse.com/#feat=server-timing)
- resize-observer: [Resize Observer](https://caniuse.com/#feat=resizeobserver)
- shared-array-buffer: [Shared Array Buffer](https://caniuse.com/#feat=sharedarraybuffer)
- web-assembly: [WebAssembly](https://caniuse.com/#feat=wasm)
- web-authentication: [Web Authentication API](https://caniuse.com/#feat=webauthn)
- webgl-2: [WebGL 2.0](https://caniuse.com/#feat=webgl2)

This PR will also fix following travis-ci error as 'mdn-css_types_clamp' is changed to 'css-math-functions'.

https://travis-ci.org/github/mozilla/platform-status/jobs/676341525
> Error: Can't find 'mdn-css_types_clamp' feature on caniuse.com.