### PR TITLE
Add webkit_ref to platform status entries

### DIFF
--- a/features/asmjs.md
+++ b/features/asmjs.md
@@ -6,7 +6,7 @@ bugzilla: 868184
 mdn_url: https://developer.mozilla.org/en-US/docs/Games/Tools/asm.js
 spec_url: http://asmjs.org/spec/latest/
 spec_status: working-draft-or-equivalent
-webkit_ref: ASM.js
+webkit_ref:
 chrome_ref: 5053365658583040
 ie_ref: ASM.js
 caniuse_ref: asmjs

--- a/features/async-clipboard.md
+++ b/features/async-clipboard.md
@@ -7,6 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
 spec_url: https://w3c.github.io/clipboard-apis/#async-clipboard-api
 spec_repo: https://github.com/w3c/clipboard-apis
 chrome_ref: 5861289330999296
+webkit_ref: Async Clipboard API
 ---
 
 Allows read and write access to the contents of the system clipboard; can be used to implement cut, copy, and paste features within a web application.

--- a/features/async-function.md
+++ b/features/async-function.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/State
 spec_url: https://tc39.github.io/ecmascript-asyncawait/
 spec_repo: https://github.com/tc39/ecmascript-asyncawait
 caniuse_ref: async-functions
-webkit_ref:
+webkit_ref: async/await
 chrome_ref: 5643236399906816
 ie_ref: Async Functions
 firefox_footnote: https://blog.nightly.mozilla.org/2016/11/01/async-await-support-in-firefox/

--- a/features/block-autoplay.md
+++ b/features/block-autoplay.md
@@ -4,7 +4,7 @@ category: apps, multimedia
 bugzilla: 1487844
 firefox_status: 66
 chrome_ref: 5700102471548928
-webkit_ref: Scroll Anchoring
+webkit_status: shipped
 ---
 
 A policy that stops audio content from autoplaying on web pages unless it is initiated by a user gesture (e.g. a click event).

--- a/features/canvas-media-capture.md
+++ b/features/canvas-media-capture.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/capt
 spec_url: https://w3c.github.io/mediacapture-fromelement/index.html#idl-def-CanvasCaptureMediaStream
 spec_repo: https://github.com/w3c/mediacapture-fromelement
 chrome_ref: 4817998447640576
-webkit_ref:
+webkit_status: shipped # this is part of Media Capture and Streams
 opera_ref:
 ie_ref:
 ---

--- a/features/css-backdrop-filter.md
+++ b/features/css-backdrop-filter.md
@@ -6,7 +6,7 @@ firefox_status: under-consideration
 mdn_url: https://developer.mozilla.org/docs/Web/CSS/backdrop-filter
 spec_url: https://dev.w3.org/fxtf/filters-2/#BackdropFilterPropert
 caniuse_ref: css-backdrop-filter
-webkit_ref: feature-filter-effects-backdrop-filter-property
+webkit_ref: Filter Effects backdrop-filter property
 chrome_ref: 5679432723333120
 ie_ref: Backdrop filter
 ---

--- a/features/css-clip-path.md
+++ b/features/css-clip-path.md
@@ -7,6 +7,7 @@ mdn_url: https://developer.mozilla.org/Web/CSS/clip-path
 spec_url: https://drafts.fxtf.org/css-masking-1/#the-clip-path
 caniuse_ref: css-clip-path
 chrome_ref: 5742325112242176
+webkit_status: shipped # this is part of CSS Masking Level 1
 ---
 
 Defines a shape as a clipping region over an element. Only the parts of the element inside the clipping region are displayed.

--- a/features/css-logical-properties.md
+++ b/features/css-logical-properties.md
@@ -7,6 +7,7 @@ spec_url: https://drafts.csswg.org/css-logical/
 caniuse_ref: css-logical-props
 chrome_ref: 6237096230518784
 ie_ref: 'CSS Logical Properties Level 1'
+webkit_ref: CSS Logical Properties and Values Level 1
 ---
 
 Provides the ability to control layout through logical, rather than physical, direction and dimension mappings, e.g. inline-start and inline-end rather than left and right.

--- a/features/css-scroll-snap.md
+++ b/features/css-scroll-snap.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap
 spec_url: https://drafts.csswg.org/css-scroll-snap-1/
 spec_repo: https://github.com/w3c/csswg-drafts/tree/master/css-scroll-snap-1
 caniuse_ref: css-snappoints
-webkit_ref: specification-css-scroll-snap-points-module-level-1
+webkit_ref: CSS Scroll Snap Points Module Level 1
 chrome_ref: 5721832506261504
 ie_ref: CSS Scroll Snap Points
 ---

--- a/features/dialog-element.md
+++ b/features/dialog-element.md
@@ -9,6 +9,7 @@ spec_repo: https://github.com/whatwg/html
 chrome_ref: 5770237022568448
 ie_ref: <dialog> element for modals
 caniuse_ref: dialog
+webkit_ref: Dialog Element
 ---
 
 Provides semantics for marking up modal dialogs, along with access to useful related functionality.

--- a/features/fetch.md
+++ b/features/fetch.md
@@ -8,7 +8,7 @@ spec_url: https://fetch.spec.whatwg.org/
 spec_repo: https://github.com/whatwg/fetch
 chrome_ref: 6730533392351232
 ie_ref: Fetch API
-webkit_ref: Fetch API
+webkit_ref: Fetch
 caniuse_ref: fetch
 ---
 

--- a/features/gamepad.md
+++ b/features/gamepad.md
@@ -9,6 +9,7 @@ spec_repo: https://github.com/w3c/gamepad/
 chrome_ref: 5118776383111168
 ie_ref: GamePad API
 caniuse_ref: gamepad
+webkit_ref: Gamepad
 ---
 
 Provides access and responses to signals from gamepads and other game controllers.

--- a/features/html-templates.md
+++ b/features/html-templates.md
@@ -5,7 +5,7 @@ firefox_status: 22
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 spec_url: https://html.spec.whatwg.org/multipage//scripting.html#the-template-element
 chrome_ref: 5207287069147136
-webkit_ref: Web Components
+webkit_ref: Template Element
 ie_ref: <template> Element
 caniuse_ref: template
 ---

--- a/features/htmlcanvaselement-toblob.md
+++ b/features/htmlcanvaselement-toblob.md
@@ -7,6 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBl
 spec_url: https://html.spec.whatwg.org/multipage/scripting.html#dom-canvas-toblob
 chrome_ref: 4562033294966784
 ie_ref: HTMLCanvasElement toBlob method
+webkit_status: shipped
 ---
 
 Creates a Blob object representing a file containing an image captured from a canvas.

--- a/features/javascript-modules.md
+++ b/features/javascript-modules.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules
 spec_url: https://tc39.github.io/ecma262/#sec-modules
 spec_repo: https://github.com/tc39/ecma262
 caniuse_ref: es6-module
-webkit_ref: modules
+webkit_ref: Modules
 chrome_ref: 5365692190687232
 ie_ref: Modules (ES6)
 ---

--- a/features/media-recorder.md
+++ b/features/media-recorder.md
@@ -7,6 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder
 spec_url: https://w3c.github.io/mediacapture-record/MediaRecorder.html
 chrome_ref: 5929649028726784
 ie_ref: MediaRecorder
+webkit_ref: MediaStream Recording API
 ---
 
 Provides the ability to encode audio and video streams on the fly in the browser.

--- a/features/microtask-api.md
+++ b/features/microtask-api.md
@@ -7,6 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalSc
 spec_url: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#microtask-queuing
 spec_repo: https://github.com/whatwg/html
 chrome_ref: 5111086432911360
+webkit_status: shipped
 ---
 
 Adds a new method, queueMicrotask(), which allows direct queueing of a callback to run as a microtask. Microtasks are callbacks that run just before the current task ends.

--- a/features/performance-server-timing.md
+++ b/features/performance-server-timing.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTimin
 spec_url: https://w3c.github.io/server-timing/
 chrome_ref: 5695708376072192
 ie_ref: Server Timing
-webkit_ref: Navigation Timing Level 2
+webkit_ref:
 
 ---
 

--- a/features/pointer-events.md
+++ b/features/pointer-events.md
@@ -9,6 +9,7 @@ spec_repo: https://github.com/w3c/pointerevents/
 chrome_ref: 4504699138998272
 ie_ref: Pointer Events
 caniuse_ref: pointer
+webkit_ref: Pointer Events Level 2
 ---
 
 Handles hardware-agnostic pointer input from devices including mouse, pen, touchscreen, etc.

--- a/features/pointerlock.md
+++ b/features/pointerlock.md
@@ -9,6 +9,7 @@ spec_repo: https://github.com/w3c/pointerlock
 chrome_ref: 6753200417800192
 ie_ref: Pointer Lock (Mouse Lock)
 caniuse_ref: pointerlock
+webkit_ref: Pointer Lock
 ---
 
 Provides access to raw mouse movement, locks the target of mouse events to a single element, eliminates limits of how far mouse movement can go in a single direction, and removes the cursor from view.

--- a/features/subresource-integrity.md
+++ b/features/subresource-integrity.md
@@ -8,6 +8,7 @@ spec_url: https://www.w3.org/TR/SRI/
 chrome_ref: 6183089948590080
 ie_ref: Subresource Integrity
 caniuse_ref: subresource-integrity
+webkit_ref: Subresource Integrity
 ---
 
 Provides an `integrity` attribute allowing scripts and stylesheets to protect against unexpected modifications.

--- a/features/text-decoration-4.md
+++ b/features/text-decoration-4.md
@@ -8,6 +8,7 @@ spec_url: https://drafts.csswg.org/css-text-decor-4/
 spec_repo: https://github.com/w3c/csswg-drafts/issues
 chrome_ref: 5631679087509504
 caniuse_ref: text-decoration
+webkit_ref: CSS Text Decoration Level 4
 ---
 
 A module of CSS that defines features relating to text decoration, such as underlines, text shadows, and emphasis marks. Level 4 adds new properties like `text-decoration-skip-ink`, `text-underline-offset`, and `text-decoration-thickness`.

--- a/features/visual-viewport-api.md
+++ b/features/visual-viewport-api.md
@@ -5,7 +5,7 @@ bugzilla: 1512813
 firefox_status: 68
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
 spec_url: https://wicg.github.io/visual-viewport/
-webkit_ref: feature-visual-viewport-api
+webkit_ref: Visual Viewport API
 chrome_ref: 5737866978131968
 ---
 

--- a/features/webaudio.md
+++ b/features/webaudio.md
@@ -8,6 +8,7 @@ spec_url: http://webaudio.github.io/web-audio-api/
 spec_repo: https://github.com/webaudio/web-audio-api/
 chrome_ref: 6261718720184320
 ie_ref: Web Audio API
+webkit_ref: Web Audio
 webkit_status: shipped
 caniuse_ref: audio-api
 ---

--- a/features/webvr.md
+++ b/features/webvr.md
@@ -9,7 +9,7 @@ spec_repo: https://github.com/w3c/webvr/
 chrome_ref: 4532810371039232
 ie_ref: WebVR
 caniuse_ref: webvr
-webkit_ref: WebVR
+webkit_ref:
 ---
 
 Provides support for exposing virtual reality displays — like the Oculus Rift or HTC Vive — to web apps, enabling developers to create interactive virtual reality scenes on the web platform.


### PR DESCRIPTION
This PR added `webkit_ref` to following entries to reflect WebKit's implementation status.

- asmjs: removed `webkit_ref` (WebKit Feature Status has removed the corresponding entry)
- async-clipboard: [Async Clipboard API](https://webkit.org/status/#specification-async-clipboard-api)
- async-function: [async/await](https://webkit.org/status/#feature-async/await)
- block-autoplay: added `webkit_status` (WebKit Feature Status has no corresponding entries)
- canvas-media-capture: added `webkit_status` (WebKit has supported `HTMLCanvasElement.captureStream()`)
- css-backdrop-filter: [Filter Effects backdrop-filter property](https://webkit.org/status/#feature-filter-effects-backdrop-filter-property)
- css-clip-path: added `webkit_status` (WebKit has supported `clip-path`))
- css-logical-properties: [CSS Logical Properties and Values Level 1](https://webkit.org/status/#specification-css-logical-properties-and-values-level-1)
- css-scroll-snap: [CSS Scroll Snap Points Module Level 1](https://webkit.org/status/#specification-css-scroll-snap-points-module-level-1)
- dialog-element: [Dialog Element](https://webkit.org/status/#feature-dialog-element)
- fetch: [Fetch](https://webkit.org/status/#specification-fetch)
- gamepad: [Gamepad](https://webkit.org/status/#specification-gamepad)
- html-templates: [Template Element](https://webkit.org/status/#feature-template-element)
- htmlcanvaselement-toblob: added `webkit_status` (WebKit has supported `HTMLCanvasElement.toBlob()`)
- javascript-modules: [Modules](https://webkit.org/status/#feature-modules)
- media-recorder: [MediaStream Recording API](https://webkit.org/status/#feature-mediastream-recording-api)
- microtask-api: added `webkit_status` (WebKit has supported `HTMLCanvasElement.toBlob()`)
- performance-server-timing: removed `webkit_ref` (WebKit Feature Status has no corresponding entries)
- pointer-events: [Pointer Events Level 2](https://webkit.org/status/#specification-pointer-events-level-2)
- pointerlock: [Pointer Lock](https://webkit.org/status/#specification-pointer-lock)
- subresource-integrity: [Subresource Integrity](https://webkit.org/status/#feature-subresource-integrity)
- text-decoration-4: [CSS Text Decoration Level 4](https://webkit.org/status/#specification-css-text-decoration-level-4)
- visual-viewport-api: [Visual Viewport API](https://webkit.org/status/#feature-visual-viewport-api)
- webaudio: [Web Audio](https://webkit.org/status/#feature-web-audio)
- webvr: removed `webkit_ref` (WebKit Feature Status has removed the corresponding entry)

