### PR TITLE
Add chrome_ref to platform status entries.

### DIFF
--- a/features/block-autoplay.md
+++ b/features/block-autoplay.md
@@ -3,7 +3,7 @@ title: Block autoplaying audio
 category: apps, multimedia
 bugzilla: 1487844
 firefox_status: 66
-chrome_ref: 5700102471548928
+chrome_status: shipped
 webkit_ref: Scroll Anchoring
 ---
 

--- a/features/css-font-variation-settings.md
+++ b/features/css-font-variation-settings.md
@@ -7,7 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-setting
 spec_url: https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-the-font-variation-settings-property
 caniuse_ref: variable-fonts
 webkit_ref: Variation Fonts
-chrome_ref: 5831574356492288
+chrome_ref: 4708676673732608
 ie_ref: Font Variation Properties with OpenType Variable Font Support
 ---
 

--- a/features/css-individual-transforms.md
+++ b/features/css-individual-transforms.md
@@ -6,7 +6,7 @@ firefox_status: 72
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transforms
 spec_url: https://drafts.csswg.org/css-transforms-2/#individual-transforms
 spec_repo: https://github.com/w3c/csswg-drafts/
-chrome_ref: 5763933658939392
+chrome_ref: 5705698193178624
 ---
 
 Provides individual properties for setting transforms — `rotate`, `scale`, and `translate`. These are easier to write than the equivalent individual transforms, and map better to typical user interface usage.

--- a/features/css-steps-timing-functions.md
+++ b/features/css-steps-timing-functions.md
@@ -6,7 +6,7 @@ firefox_status: 65
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/CSS/timing-function#The_steps()_class_of_timing_functions
 spec_url: https://drafts.csswg.org/css-easing-1/#step-timing-functions
 caniuse_ref: css-animation
-chrome_ref: 5189363944128512
+chrome_ref: 5730327525851136
 ---
 
 Allows an animation to occur in equidistant steps, rather than a smooth motion. Formerly frames().

--- a/features/formdataevent.md
+++ b/features/formdataevent.md
@@ -6,7 +6,7 @@ firefox_status: 72
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects#Using_a_formdata_event
 spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-formdataevent-interface
 spec_repo: https://github.com/whatwg/html/
-chrome_ref: 5763933658939392
+chrome_ref: 5662230242656256
 ---
 
 Provides a new event, `formdata`, which can be used to conveniently collect the data contained in a form as a `FormData` object before submitting it e.g. via XHR.

--- a/features/prefers-reduced-motion.md
+++ b/features/prefers-reduced-motion.md
@@ -9,6 +9,7 @@ spec_repo: https://github.com/w3c/csswg-drafts/tree/master/mediaqueries-5
 ie_ref: 'Media Queries: prefers-reduced-motion'
 webkit_status: shipped
 caniuse_ref: prefers-reduced-motion
+chrome_ref: 5597964353404928
 ---
 
 Used to detect if the user has enabled their system's setting for minimizing the amount of animation or motion it uses.


### PR DESCRIPTION
This PR added `chrome_ref` to following entries to reflect Chrome's implementation status.

- block-autoplay: added `chrome_status` (Chrome Platform Status has no corresponding entries)
- css-font-variation-settings: [OpenType variable font support](https://www.chromestatus.com/feature/4708676673732608)
- css-individual-transforms: [Independent Properties for CSS Transforms](https://www.chromestatus.com/feature/5705698193178624)
- css-steps-timing-functions: [Support step timing functions jump-start|end|both|none](https://www.chromestatus.com/feature/5730327525851136)
- formdataevent: ['formdata' event](https://www.chromestatus.com/feature/5662230242656256)
- prefers-reduced-motion: [prefers-reduced-motion media query](https://caniuse.com/#feat=prefers-reduced-motion)